### PR TITLE
Remove legacy transformed model API

### DIFF
--- a/src/inference/dev_api/openvino/runtime/icore.hpp
+++ b/src/inference/dev_api/openvino/runtime/icore.hpp
@@ -171,18 +171,6 @@ public:
                                             const std::string& device_name,
                                             const ov::AnyMap& config) const = 0;
     /**
-     * @brief Get a transformed model of the input model with specified configuration
-     *
-     * @param model OpenVINO Model to be transformed
-     * @param device_name The target device name for which the transformation should be applied
-     * @param config Optional map of pairs: (config parameter name, config parameter value)
-     * @return A shared pointer to the transformed ov::Model object
-     */
-    virtual std::shared_ptr<ov::Model> get_transformed_model(const std::shared_ptr<const ov::Model>& model,
-                                                             const std::string& device_name,
-                                                             const ov::AnyMap& config) const = 0;
-
-    /**
      * @brief Returns devices available for neural networks inference
      *
      * @return A vector of devices. The devices are returned as { CPU, GPU.0, GPU.1, MYRIAD }

--- a/src/inference/dev_api/openvino/runtime/iplugin.hpp
+++ b/src/inference/dev_api/openvino/runtime/iplugin.hpp
@@ -217,16 +217,6 @@ public:
                                             const ov::AnyMap& properties) const = 0;
 
     /**
-     * @brief Get a transformed model of the input model with specified configuration
-     *
-     * @param model OpenVINO Model to be transformed
-     * @param properties Optional map of pairs: (property name, property value).
-     * @return A shared pointer to the transformed ov::Model object
-     */
-    virtual std::shared_ptr<ov::Model> get_transformed_model(const std::shared_ptr<const ov::Model>& model,
-                                                             const ov::AnyMap& properties) const;
-
-    /**
      * @brief Sets pointer to ICore interface
      * @param core Pointer to Core interface
      */

--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -4,10 +4,8 @@
 
 #include "core_impl.hpp"
 
-#include <algorithm>
 #include <memory>
 #include <variant>
-#include <vector>
 
 #include "check_network_batchable.hpp"
 #include "itt.hpp"

--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -4,8 +4,10 @@
 
 #include "core_impl.hpp"
 
+#include <algorithm>
 #include <memory>
 #include <variant>
+#include <vector>
 
 #include "check_network_batchable.hpp"
 #include "itt.hpp"
@@ -976,14 +978,6 @@ ov::SupportedOpsMap ov::CoreImpl::query_model(const std::shared_ptr<const ov::Mo
     OV_ITT_SCOPED_TASK(ov::itt::domains::OV, "Core::query_model");
     auto parsed = parseDeviceNameIntoConfig(device_name, config);
     return get_plugin(parsed._deviceName).query_model(model, parsed._config);
-}
-
-std::shared_ptr<ov::Model> ov::CoreImpl::get_transformed_model(const std::shared_ptr<const ov::Model>& model,
-                                                               const std::string& device_name,
-                                                               const ov::AnyMap& config) const {
-    OV_ITT_SCOPED_TASK(ov::itt::domains::OV, "Core::get_transformed_model");
-    auto parsed = parseDeviceNameIntoConfig(device_name, config);
-    return get_plugin(parsed._deviceName).get_transformed_model(model, parsed._config);
 }
 
 bool ov::CoreImpl::is_hidden_device(const std::string& device_name) const {

--- a/src/inference/src/dev/core_impl.hpp
+++ b/src/inference/src/dev/core_impl.hpp
@@ -351,10 +351,6 @@ public:
                                     const std::string& device_name,
                                     const ov::AnyMap& config) const override;
 
-    std::shared_ptr<ov::Model> get_transformed_model(const std::shared_ptr<const ov::Model>& model,
-                                                     const std::string& device_name,
-                                                     const ov::AnyMap& config) const override;
-
     std::vector<std::string> get_available_devices() const override;
 
     ov::SoPtr<ov::IRemoteContext> create_context(const std::string& device_name, const AnyMap& args) const override;

--- a/src/inference/src/dev/iplugin.cpp
+++ b/src/inference/src/dev/iplugin.cpp
@@ -68,11 +68,6 @@ std::shared_ptr<ov::ICore> ov::IPlugin::get_core() const {
     return m_core.lock();
 }
 
-std::shared_ptr<ov::Model> ov::IPlugin::get_transformed_model(const std::shared_ptr<const ov::Model>& model,
-                                                              const ov::AnyMap& properties) const {
-    return model->clone();
-}
-
 const std::shared_ptr<ov::threading::ExecutorManager>& ov::IPlugin::get_executor_manager() const {
     return m_executor_manager;
 }

--- a/src/inference/src/dev/plugin.cpp
+++ b/src/inference/src/dev/plugin.cpp
@@ -69,11 +69,6 @@ ov::SupportedOpsMap ov::Plugin::query_model(const std::shared_ptr<const ov::Mode
     OV_PLUGIN_CALL_STATEMENT(return m_ptr->query_model(model, properties));
 }
 
-std::shared_ptr<ov::Model> ov::Plugin::get_transformed_model(const std::shared_ptr<const ov::Model>& model,
-                                                             const ov::AnyMap& properties) const {
-    OV_PLUGIN_CALL_STATEMENT(return m_ptr->get_transformed_model(model, properties));
-}
-
 ov::SoPtr<ov::ICompiledModel> ov::Plugin::import_model(std::istream& model, const ov::AnyMap& properties) const {
     OV_PLUGIN_CALL_STATEMENT(return {m_ptr->import_model(model, properties), m_so});
 }

--- a/src/inference/src/dev/plugin.hpp
+++ b/src/inference/src/dev/plugin.hpp
@@ -53,9 +53,6 @@ public:
 
     ov::SupportedOpsMap query_model(const std::shared_ptr<const ov::Model>& model, const ov::AnyMap& properties) const;
 
-    std::shared_ptr<ov::Model> get_transformed_model(const std::shared_ptr<const ov::Model>& model,
-                                                     const ov::AnyMap& properties) const;
-
     SoPtr<ov::ICompiledModel> import_model(ov::Tensor& model, const ov::AnyMap& properties) const;
 
     SoPtr<ov::ICompiledModel> import_model(ov::Tensor& model,

--- a/src/plugins/hetero/src/plugin.cpp
+++ b/src/plugins/hetero/src/plugin.cpp
@@ -4,6 +4,7 @@
 
 #include "plugin.hpp"
 
+#include <algorithm>
 #include <fstream>
 #include <map>
 #include <memory>
@@ -316,8 +317,49 @@ ov::hetero::Plugin::QueryResult ov::hetero::Plugin::query_model_update(const std
         }
     };
     if (all_same_gpu_type(device_names) && hetero_query_model_by_device) {
-        auto& first_device_config = properties_per_device.at(device_names[0]);
-        res.model = get_core()->get_transformed_model(model, device_names[0], first_device_config);
+        const auto& first_device_name = device_names[0];
+        const auto& first_device_config = properties_per_device.at(first_device_name);
+
+        static constexpr const char* transformed_model_property_name = "GPU_TRANSFORMED_MODEL";
+
+        std::vector<ov::PropertyName> supported_internal_properties;
+        try {
+            supported_internal_properties =
+                get_core()->get_property<std::vector<ov::PropertyName>>(first_device_name,
+                                                                        ov::internal::supported_properties);
+        } catch (const ov::Exception& ex) {
+            OPENVINO_THROW("Device ",
+                            first_device_name,
+                            " failed to report supported internal properties required to obtain ",
+                            transformed_model_property_name,
+                            ": ",
+                            ex.what());
+        }
+
+        const bool has_transformed_model_property = std::any_of(supported_internal_properties.begin(),
+                                                                supported_internal_properties.end(),
+                                                                [transformed_model_property_name](
+                                                                    const ov::PropertyName& property) {
+                                                                    return property == transformed_model_property_name;
+                                                                });
+
+        OPENVINO_ASSERT(has_transformed_model_property,
+                        "Device ",
+                        first_device_name,
+                        " does not expose internal property ",
+                        transformed_model_property_name);
+
+        ov::AnyMap property_request{first_device_config.begin(), first_device_config.end()};
+        property_request[ov::hint::model.name()] = model;
+
+        auto transformed_model = get_core()
+                                     ->get_property(first_device_name, transformed_model_property_name, property_request)
+                                     .as<std::shared_ptr<ov::Model>>();
+        OPENVINO_ASSERT(transformed_model,
+                        "Received empty transformed model from device ",
+                        first_device_name);
+
+        res.model = transformed_model;
         res.is_transformed = true;
     } else {
         res.model = model;

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/plugin.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/plugin.hpp
@@ -65,8 +65,6 @@ public:
                                                      const ov::AnyMap& properties) const override;
     ov::SupportedOpsMap query_model(const std::shared_ptr<const ov::Model>& model,
                                     const ov::AnyMap& properties) const override;
-    std::shared_ptr<ov::Model> get_transformed_model(const std::shared_ptr<const ov::Model>& model,
-                                                     const ov::AnyMap& properties) const override;
     ov::SoPtr<ov::IRemoteContext> create_context(const ov::AnyMap& remote_properties) const override;
     ov::SoPtr<ov::IRemoteContext> get_default_context(const ov::AnyMap& remote_properties) const override;
 };

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/internal_properties.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/internal_properties.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "intel_gpu/runtime/shape_predictor.hpp"
+#include "openvino/core/model.hpp"
 #include "openvino/runtime/properties.hpp"
 #include "openvino/runtime/intel_gpu/properties.hpp"
 
@@ -168,6 +169,13 @@ static constexpr Property<ShapePredictor::Settings, ov::PropertyMutability::RW> 
 static constexpr Property<std::vector<std::string>, ov::PropertyMutability::RW> load_dump_raw_binary{"GPU_LOAD_DUMP_RAW_BINARY"};
 static constexpr Property<bool, ov::PropertyMutability::RW> could_use_flashattn_v2{"GPU_COULD_USE_FLASHATTN_V2"};
 static constexpr Property<uint64_t, PropertyMutability::RW> dynamic_quantization_group_size_max{"GPU_DYNAMIC_QUANTIZATION_GROUP_SIZE_MAX"};
+
+namespace internal {
+/**
+ * @brief Read-only property to get a transformed ov::Model for provided compilation options.
+ */
+static constexpr Property<std::shared_ptr<ov::Model>, PropertyMutability::RO> transformed_model{"GPU_TRANSFORMED_MODEL"};
+}  // namespace internal
 }  // namespace ov::intel_gpu
 
 namespace cldnn {

--- a/src/tests/test_utils/unit_test_utils/mocks/openvino/runtime/mock_icore.hpp
+++ b/src/tests/test_utils/unit_test_utils/mocks/openvino/runtime/mock_icore.hpp
@@ -26,10 +26,6 @@ public:
                 query_model,
                 (const std::shared_ptr<const ov::Model>&, const std::string&, const ov::AnyMap&),
                 (const));
-    MOCK_METHOD(std::shared_ptr<ov::Model>,
-                get_transformed_model,
-                (const std::shared_ptr<const ov::Model>&, const std::string&, const ov::AnyMap&),
-                (const));
     MOCK_METHOD(ov::SoPtr<ov::ICompiledModel>,
                 import_model,
                 (std::istream&, const std::string&, const ov::AnyMap&),


### PR DESCRIPTION
## Summary
- switch the hetero plugin to fetch GPU-transformed models via the GPU_TRANSFORMED_MODEL internal property
- remove the obsolete get_transformed_model API from the runtime interfaces, wrappers, and GPU plugin implementation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68faf2a73cd48331ad3f452b8986727d