### PR TITLE
Add CM xattn find block primitive and unit test

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/xattn_find_block.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/xattn_find_block.hpp
@@ -1,0 +1,137 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "primitive.hpp"
+
+#include <cstdint>
+#include <vector>
+
+namespace cldnn {
+
+/// @brief Primitive that wraps XAttention find_block CM kernel.
+struct xattn_find_block : public primitive_base<xattn_find_block> {
+    CLDNN_DECLARE_PRIMITIVE(xattn_find_block)
+
+    xattn_find_block()
+        : primitive_base("", {}) {}
+
+    xattn_find_block(const primitive_id& id,
+                     const std::vector<input_info>& inputs,
+                     uint32_t heads_num,
+                     uint32_t head_size,
+                     uint32_t q_len,
+                     uint32_t q_stride,
+                     uint32_t k_stride,
+                     uint32_t q_stride_pad,
+                     uint32_t q_block_pad,
+                     uint32_t k_block_pad,
+                     int32_t causal_start_index,
+                     float thresh,
+                     uint32_t stride = 16,
+                     uint32_t block_size = 128,
+                     bool is_causal = true,
+                     bool use_int8 = false)
+        : primitive_base(id, inputs, 1, {optional_data_type(data_types::u8)})
+        , heads_num(heads_num)
+        , head_size(head_size)
+        , q_len(q_len)
+        , q_stride(q_stride)
+        , k_stride(k_stride)
+        , q_stride_pad(q_stride_pad)
+        , q_block_pad(q_block_pad)
+        , k_block_pad(k_block_pad)
+        , causal_start_index(causal_start_index)
+        , thresh(thresh)
+        , stride(stride)
+        , block_size(block_size)
+        , is_causal(is_causal)
+        , use_int8(use_int8) {}
+
+    uint32_t heads_num = 0;
+    uint32_t head_size = 0;
+    uint32_t q_len = 0;
+    uint32_t q_stride = 0;
+    uint32_t k_stride = 0;
+    uint32_t q_stride_pad = 0;
+    uint32_t q_block_pad = 0;
+    uint32_t k_block_pad = 0;
+    int32_t causal_start_index = 0;
+    float thresh = 0.f;
+    uint32_t stride = 16;
+    uint32_t block_size = 128;
+    bool is_causal = true;
+    bool use_int8 = false;
+
+    size_t hash() const override {
+        size_t seed = primitive::hash();
+        seed = hash_combine(seed, heads_num);
+        seed = hash_combine(seed, head_size);
+        seed = hash_combine(seed, q_len);
+        seed = hash_combine(seed, q_stride);
+        seed = hash_combine(seed, k_stride);
+        seed = hash_combine(seed, q_stride_pad);
+        seed = hash_combine(seed, q_block_pad);
+        seed = hash_combine(seed, k_block_pad);
+        seed = hash_combine(seed, causal_start_index);
+        seed = hash_combine(seed, thresh);
+        seed = hash_combine(seed, stride);
+        seed = hash_combine(seed, block_size);
+        seed = hash_combine(seed, is_causal);
+        seed = hash_combine(seed, use_int8);
+        return seed;
+    }
+
+    bool operator==(const primitive& rhs) const override {
+        if (!compare_common_params(rhs))
+            return false;
+
+        const auto& typed_rhs = static_cast<const xattn_find_block&>(rhs);
+        return heads_num == typed_rhs.heads_num && head_size == typed_rhs.head_size && q_len == typed_rhs.q_len &&
+               q_stride == typed_rhs.q_stride && k_stride == typed_rhs.k_stride && q_stride_pad == typed_rhs.q_stride_pad &&
+               q_block_pad == typed_rhs.q_block_pad && k_block_pad == typed_rhs.k_block_pad &&
+               causal_start_index == typed_rhs.causal_start_index && thresh == typed_rhs.thresh &&
+               stride == typed_rhs.stride && block_size == typed_rhs.block_size && is_causal == typed_rhs.is_causal &&
+               use_int8 == typed_rhs.use_int8;
+    }
+
+    void save(BinaryOutputBuffer& ob) const override {
+        primitive_base<xattn_find_block>::save(ob);
+        ob << heads_num;
+        ob << head_size;
+        ob << q_len;
+        ob << q_stride;
+        ob << k_stride;
+        ob << q_stride_pad;
+        ob << q_block_pad;
+        ob << k_block_pad;
+        ob << causal_start_index;
+        ob << thresh;
+        ob << stride;
+        ob << block_size;
+        ob << is_causal;
+        ob << use_int8;
+    }
+
+    void load(BinaryInputBuffer& ib) override {
+        primitive_base<xattn_find_block>::load(ib);
+        ib >> heads_num;
+        ib >> head_size;
+        ib >> q_len;
+        ib >> q_stride;
+        ib >> k_stride;
+        ib >> q_stride_pad;
+        ib >> q_block_pad;
+        ib >> k_block_pad;
+        ib >> causal_start_index;
+        ib >> thresh;
+        ib >> stride;
+        ib >> block_size;
+        ib >> is_causal;
+        ib >> use_int8;
+    }
+};
+
+}  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/impls/cm/xattn_find_block.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/xattn_find_block.cpp
@@ -1,0 +1,154 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "xattn_find_block.hpp"
+
+#include <cmath>
+#include <cstring>
+#include <memory>
+#include <utility>
+
+#include "common_utils/kernel_generator_base.hpp"
+#include "intel_gpu/runtime/utils.hpp"
+#include "primitive_cm_base.hpp"
+#include "primitive_inst.h"
+#include "registry/implementation_manager.hpp"
+#include "utils/kernel_generator.hpp"
+
+namespace ov::intel_gpu::cm {
+namespace {
+
+constexpr auto get_find_block_build_options() {
+    return " -cmc -Qxcm_register_file_size=256";
+}
+
+constexpr uint32_t SG_M = 4;
+constexpr uint32_t SG_N = 8;
+constexpr uint32_t BLOCK_SG_M = 64;
+constexpr uint32_t BLOCK_SG_N = 32;
+constexpr uint32_t BLOCK_SHARE_MAX = BLOCK_SG_N * SG_N;
+constexpr uint32_t KV_BLOCK_SIZE = 256;
+
+class XAttnFindBlockGenerator : public KernelGenerator {
+public:
+    XAttnFindBlockGenerator() : KernelGenerator("xattn_find_block") {}
+
+protected:
+    [[nodiscard]] std::string get_build_options(const RuntimeParams& params) const override {
+        return KernelGenerator::get_build_options(params) + get_find_block_build_options();
+    }
+
+    [[nodiscard]] JitConstants get_jit_constants(const RuntimeParams& params) const override {
+        auto jit = KernelGenerator::get_jit_constants(params);
+        auto desc = params.typed_desc<xattn_find_block>();
+
+        jit.add(make_jit_constant("KERNEL_NAME", get_entry_point(params)));
+
+        const float scale_factor = 1.0f / std::sqrt(static_cast<float>(desc->head_size)) / static_cast<float>(desc->stride);
+        int scale_factor_i;
+        std::memcpy(static_cast<void*>(&scale_factor_i), &scale_factor, sizeof(scale_factor));
+
+        jit.make("STRIDE", desc->stride);
+        jit.make("HQ", desc->heads_num);
+        jit.make("HK", desc->heads_num);
+        jit.make("HEAD_SIZE", desc->head_size);
+        jit.make("SG_M", SG_M);
+        jit.make("SG_N", SG_N);
+        jit.make("BLOCK_SG_M", BLOCK_SG_M);
+        jit.make("BLOCK_SG_N", BLOCK_SG_N);
+        jit.make("BLOCK_SIZE", desc->block_size);
+        jit.make("KV_BLOCK_SIZE", KV_BLOCK_SIZE);
+        jit.add(make_jit_constant("INV_S", scale_factor_i));
+        jit.make("BLOCK_SHARE_MAX", BLOCK_SHARE_MAX);
+        jit.make("WALK_HQ", 1);
+        jit.make("IS_CAUSAL", desc->is_causal ? 1 : 0);
+        jit.make("USE_INT8", desc->use_int8 ? 1 : 0);
+        const uint32_t head_size_key = desc->use_int8 ? desc->head_size + 4 : desc->head_size;
+        jit.make("HEAD_SIZE_KEY", head_size_key);
+        jit.make("SOFTMAX_TYPE", "float");
+
+        return jit;
+    }
+
+    [[nodiscard]] Arguments get_arguments_desc(const RuntimeParams& params) const override {
+        Arguments args;
+
+        args.push_back({ArgumentDescriptor::Types::INPUT, 0});
+        args.push_back({ArgumentDescriptor::Types::INPUT, 1});
+        args.push_back({ArgumentDescriptor::Types::OUTPUT, 0});
+
+        args.push_back({ArgumentDescriptor::Types::SCALAR, 0});
+        args.push_back({ArgumentDescriptor::Types::SCALAR, 1});
+        args.push_back({ArgumentDescriptor::Types::SCALAR, 2});
+        args.push_back({ArgumentDescriptor::Types::SCALAR, 3});
+        args.push_back({ArgumentDescriptor::Types::SCALAR, 4});
+        args.push_back({ArgumentDescriptor::Types::SCALAR, 5});
+        args.push_back({ArgumentDescriptor::Types::SCALAR, 6});
+
+        return args;
+    }
+
+    [[nodiscard]] DispatchDataFunc get_dispatch_data_func() const override {
+        return DispatchDataFunc{[](const RuntimeParams& params, KernelData& kd, ImplRuntimeParams* /*rt_params*/) {
+            auto desc = params.typed_desc<xattn_find_block>();
+
+            auto& wgs = kd.params.workGroups;
+            wgs.global = {desc->q_block_pad, desc->heads_num, 1};
+            wgs.local = {1, 1, 1};
+
+            const uint32_t tokens_per_block = desc->block_size / desc->stride;
+            const uint32_t q_block = cldnn::ceil_div(desc->q_stride, tokens_per_block);
+            const uint32_t k_block = cldnn::ceil_div(desc->k_stride, tokens_per_block);
+
+            auto& scalars = kd.params.scalars;
+            std::vector<uint32_t> scalar_values = {desc->q_len,
+                                                   desc->q_stride,
+                                                   desc->q_stride_pad,
+                                                   desc->q_block_pad,
+                                                   desc->k_block_pad,
+                                                   (k_block >= q_block) ? k_block - q_block : 0u};
+            scalars.resize(scalar_values.size() + 1);
+
+            for (size_t i = 0; i < scalar_values.size(); ++i) {
+                scalars[i].t = ScalarDescriptor::Types::UINT32;
+                scalars[i].v.u32 = scalar_values[i];
+            }
+
+            scalars[scalar_values.size()].t = ScalarDescriptor::Types::FLOAT32;
+            scalars[scalar_values.size()].v.f32 = desc->thresh;
+        }};
+    }
+};
+
+class XAttnFindBlockCmImpl : public PrimitiveImplCM {
+public:
+    DECLARE_OBJECT_TYPE_SERIALIZATION(ov::intel_gpu::cm::XAttnFindBlockCmImpl)
+
+    Stage::Ptr find_block = make_stage<XAttnFindBlockGenerator>();
+
+    XAttnFindBlockCmImpl() : PrimitiveImplCM(XAttnFindBlockImplementationManager::get_type_info_static()) {}
+    XAttnFindBlockCmImpl(const program_node& node, const RuntimeParams& params) : XAttnFindBlockCmImpl() {
+        add_stage(find_block, params);
+    }
+
+    [[nodiscard]] std::unique_ptr<primitive_impl> clone() const override {
+        return make_deep_copy<XAttnFindBlockCmImpl>(this);
+    }
+};
+
+}  // namespace
+
+std::unique_ptr<primitive_impl> XAttnFindBlockImplementationManager::create_impl(const program_node& node,
+                                                                                 const RuntimeParams& params) const {
+    OPENVINO_ASSERT(node.is_type<xattn_find_block>());
+    try {
+        return std::make_unique<XAttnFindBlockCmImpl>(node, params);
+    } catch (const std::exception& e) {
+        OPENVINO_THROW("Failed to create XAttnFindBlockCmImpl: ", e.what());
+    }
+}
+
+}  // namespace ov::intel_gpu::cm
+
+BIND_BINARY_BUFFER_WITH_TYPE(ov::intel_gpu::cm::XAttnFindBlockCmImpl)

--- a/src/plugins/intel_gpu/src/graph/impls/cm/xattn_find_block.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/xattn_find_block.hpp
@@ -1,0 +1,62 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include "intel_gpu/runtime/layout.hpp"
+#include "registry/implementation_manager.hpp"
+#include "xattn_find_block_inst.h"
+
+using namespace cldnn;  // TODO: Remove once namespaces are aligned
+
+namespace ov::intel_gpu::cm {
+
+struct XAttnFindBlockImplementationManager : public ImplementationManager {
+    OV_GPU_PRIMITIVE_IMPL("cm::xattn_find_block")
+    explicit XAttnFindBlockImplementationManager(shape_types shape_type, ValidateFunc vf = nullptr)
+        : ImplementationManager(impl_types::cm, shape_type, std::move(vf)) {}
+
+    [[nodiscard]] in_out_fmts_t query_formats(const program_node& node) const override {
+        assert(node.is_type<xattn_find_block>());
+        std::vector<format::type> in_fmts(node.get_dependencies().size(), format::any);
+        std::vector<format::type> out_fmts(node.get_outputs_count(), format::any);
+        return {in_fmts, out_fmts};
+    }
+
+    [[nodiscard]] std::unique_ptr<primitive_impl> create_impl(const program_node& node, const RuntimeParams& params) const override;
+
+    [[nodiscard]] bool validate_impl(const program_node& node) const override {
+        assert(node.is_type<xattn_find_block>());
+
+        auto& engine = node.get_program().get_engine();
+        const auto& config = node.get_program().get_config();
+
+        if (!check_cm_jit_support(engine, config) || !config.get_use_cm()) {
+            return false;
+        }
+
+        if (node.is_dynamic()) {
+            return false;
+        }
+
+        const auto& input0 = node.get_input_layout(0);
+        const auto& input1 = node.get_input_layout(1);
+        const auto& output = node.get_output_layout(0);
+
+        if (input0.data_type != ov::element::f32 || input1.data_type != ov::element::f32) {
+            return false;
+        }
+
+        if (output.data_type != ov::element::u8 && output.data_type != ov::element::boolean) {
+            return false;
+        }
+
+        return true;
+    }
+};
+
+}  // namespace ov::intel_gpu::cm

--- a/src/plugins/intel_gpu/src/graph/include/xattn_find_block_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/xattn_find_block_inst.h
@@ -1,0 +1,70 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "intel_gpu/primitives/xattn_find_block.hpp"
+#include "primitive_inst.h"
+
+#include <string>
+
+namespace cldnn {
+
+template <>
+struct typed_program_node<xattn_find_block> : public typed_program_node_base<xattn_find_block> {
+    using parent = typed_program_node_base<xattn_find_block>;
+
+public:
+    using parent::parent;
+
+    program_node& input(size_t index = 0) const { return get_dependency(index); }
+
+    std::vector<size_t> get_shape_infer_dependencies() const override { return {}; }
+};
+
+using xattn_find_block_node = typed_program_node<xattn_find_block>;
+
+template <>
+class typed_primitive_inst<xattn_find_block> : public typed_primitive_inst_base<xattn_find_block> {
+    using parent = typed_primitive_inst_base<xattn_find_block>;
+
+public:
+    template <typename ShapeType>
+    static std::vector<layout> calc_output_layouts(const xattn_find_block_node&, const kernel_impl_params& impl_params) {
+        return {impl_params.get_output_layout(0)};
+    }
+
+    static layout calc_output_layout(const xattn_find_block_node& node, const kernel_impl_params& impl_params) {
+        return calc_output_layouts<ov::PartialShape>(node, impl_params)[0];
+    }
+
+    static std::string to_string(const xattn_find_block_node& node) {
+        auto node_info = node.desc_to_json();
+        auto& desc = node.get_primitive();
+        node_info->add("heads_num", desc->heads_num);
+        node_info->add("head_size", desc->head_size);
+        node_info->add("q_len", desc->q_len);
+        node_info->add("q_stride", desc->q_stride);
+        node_info->add("k_stride", desc->k_stride);
+        node_info->add("q_stride_pad", desc->q_stride_pad);
+        node_info->add("q_block_pad", desc->q_block_pad);
+        node_info->add("k_block_pad", desc->k_block_pad);
+        node_info->add("causal_start_index", desc->causal_start_index);
+        node_info->add("thresh", desc->thresh);
+        node_info->add("stride", desc->stride);
+        node_info->add("block_size", desc->block_size);
+        node_info->add("is_causal", desc->is_causal);
+        node_info->add("use_int8", desc->use_int8);
+        return node_info->to_string();
+    }
+
+    typed_primitive_inst(network& network, const xattn_find_block_node& node)
+        : parent(network, node) {}
+
+    typed_primitive_inst(network& network) : parent(network) {}
+};
+
+using xattn_find_block_inst = typed_primitive_inst<xattn_find_block>;
+
+}  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/include/xattn_find_block_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/xattn_find_block_inst.h
@@ -39,25 +39,7 @@ public:
         return calc_output_layouts<ov::PartialShape>(node, impl_params)[0];
     }
 
-    static std::string to_string(const xattn_find_block_node& node) {
-        auto node_info = node.desc_to_json();
-        auto& desc = node.get_primitive();
-        node_info->add("heads_num", desc->heads_num);
-        node_info->add("head_size", desc->head_size);
-        node_info->add("q_len", desc->q_len);
-        node_info->add("q_stride", desc->q_stride);
-        node_info->add("k_stride", desc->k_stride);
-        node_info->add("q_stride_pad", desc->q_stride_pad);
-        node_info->add("q_block_pad", desc->q_block_pad);
-        node_info->add("k_block_pad", desc->k_block_pad);
-        node_info->add("causal_start_index", desc->causal_start_index);
-        node_info->add("thresh", desc->thresh);
-        node_info->add("stride", desc->stride);
-        node_info->add("block_size", desc->block_size);
-        node_info->add("is_causal", desc->is_causal);
-        node_info->add("use_int8", desc->use_int8);
-        return node_info->to_string();
-    }
+    static std::string to_string(const xattn_find_block_node& node);
 
     typed_primitive_inst(network& network, const xattn_find_block_node& node)
         : parent(network, node) {}

--- a/src/plugins/intel_gpu/src/graph/registry/xattn_find_block_impls.cpp
+++ b/src/plugins/intel_gpu/src/graph/registry/xattn_find_block_impls.cpp
@@ -1,0 +1,25 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "intel_gpu/primitives/xattn_find_block.hpp"
+#include "registry.hpp"
+#include "primitive_inst.h"
+
+#if OV_GPU_WITH_CM
+    #include "impls/cm/xattn_find_block.hpp"
+#endif
+
+namespace ov::intel_gpu {
+
+using namespace cldnn;
+
+const std::vector<std::shared_ptr<cldnn::ImplementationManager>>& Registry<xattn_find_block>::get_implementations() {
+    static const std::vector<std::shared_ptr<ImplementationManager>> impls = {
+        OV_GPU_CREATE_INSTANCE_CM(cm::XAttnFindBlockImplementationManager, shape_types::static_shape)
+    };
+
+    return impls;
+}
+
+}  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/graph/xattn_find_block.cpp
+++ b/src/plugins/intel_gpu/src/graph/xattn_find_block.cpp
@@ -4,11 +4,40 @@
 
 #include "intel_gpu/primitives/xattn_find_block.hpp"
 
+#include "json_object.h"
 #include "primitive_inst.h"
 #include "xattn_find_block_inst.h"
+
+#include <sstream>
 
 namespace cldnn {
 
 GPU_DEFINE_PRIMITIVE_TYPE_ID(xattn_find_block);
+
+std::string typed_primitive_inst<xattn_find_block>::to_string(const xattn_find_block_node& node) {
+    const auto desc = node.get_primitive();
+    auto node_info = node.desc_to_json();
+
+    std::stringstream primitive_description;
+    json_composite info;
+    info.add("heads_num", desc->heads_num);
+    info.add("head_size", desc->head_size);
+    info.add("q_len", desc->q_len);
+    info.add("q_stride", desc->q_stride);
+    info.add("k_stride", desc->k_stride);
+    info.add("q_stride_pad", desc->q_stride_pad);
+    info.add("q_block_pad", desc->q_block_pad);
+    info.add("k_block_pad", desc->k_block_pad);
+    info.add("causal_start_index", desc->causal_start_index);
+    info.add("thresh", desc->thresh);
+    info.add("stride", desc->stride);
+    info.add("block_size", desc->block_size);
+    info.add("is_causal", desc->is_causal);
+    info.add("use_int8", desc->use_int8);
+    node_info->add("xattn_find_block_info", info);
+    node_info->dump(primitive_description);
+
+    return primitive_description.str();
+}
 
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/xattn_find_block.cpp
+++ b/src/plugins/intel_gpu/src/graph/xattn_find_block.cpp
@@ -1,0 +1,14 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "intel_gpu/primitives/xattn_find_block.hpp"
+
+#include "primitive_inst.h"
+#include "xattn_find_block_inst.h"
+
+namespace cldnn {
+
+GPU_DEFINE_PRIMITIVE_TYPE_ID(xattn_find_block);
+
+}  // namespace cldnn

--- a/src/plugins/intel_gpu/tests/unit/test_cases/xattn_find_block_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/xattn_find_block_gpu_test.cpp
@@ -1,0 +1,89 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "test_utils.h"
+
+#include <intel_gpu/primitives/input_layout.hpp>
+#include <intel_gpu/primitives/xattn_find_block.hpp>
+
+#include <vector>
+
+using namespace cldnn;
+using namespace ::tests;
+
+namespace {
+constexpr uint32_t kBlockShareMax = 256;
+}
+
+TEST(xattn_find_block_gpu, smoke_basic_mask) {
+    auto& engine = get_test_engine();
+    auto config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::use_cm(true));
+
+    const uint32_t stride = 16;
+    const uint32_t block_size = 128;
+    const uint32_t tokens_per_block = block_size / stride;
+    const uint32_t token_share_max = kBlockShareMax / tokens_per_block;
+
+    const uint32_t heads_num = 1;
+    const uint32_t head_size = 128;
+    const uint32_t q_stride = 8;
+    const uint32_t k_stride = 32;
+    const uint32_t q_stride_pad = 8;
+    const uint32_t q_block_pad = 1;
+    const uint32_t k_block_pad = 32;
+    const uint32_t q_len = q_stride * stride;
+    const int32_t causal_start_index = 0;
+    const float thresh = 0.0f;
+
+    const uint32_t max_elements = q_stride_pad * (k_block_pad / token_share_max);
+    const uint32_t exp_elements = q_stride_pad * k_block_pad;
+    const uint32_t mask_elements = k_block_pad;
+
+    auto kq_max_layout = layout{ data_types::f32, format::bfyx, { 1, 1, 1, static_cast<int>(max_elements) } };
+    auto kq_exp_layout = layout{ data_types::f32, format::bfyx, { 1, 1, 1, static_cast<int>(exp_elements) } };
+
+    auto kq_max_mem = engine.allocate_memory(kq_max_layout);
+    auto kq_exp_mem = engine.allocate_memory(kq_exp_layout);
+
+    set_values(kq_max_mem, std::vector<float>(max_elements, 0.0f));
+    set_values(kq_exp_mem, std::vector<float>(exp_elements, 1.0f));
+
+    topology topo;
+    topo.add(input_layout("kq_max", kq_max_mem->get_layout()));
+    topo.add(input_layout("kq_exp", kq_exp_mem->get_layout()));
+    topo.add(xattn_find_block("find",
+                              {input_info("kq_max"), input_info("kq_exp")},
+                              heads_num,
+                              head_size,
+                              q_len,
+                              q_stride,
+                              k_stride,
+                              q_stride_pad,
+                              q_block_pad,
+                              k_block_pad,
+                              causal_start_index,
+                              thresh,
+                              stride,
+                              block_size,
+                              true,
+                              false));
+
+    network network(engine, topo, config);
+    network.set_input_data("kq_max", kq_max_mem);
+    network.set_input_data("kq_exp", kq_exp_mem);
+
+    auto outputs = network.execute();
+    ASSERT_TRUE(outputs.count("find"));
+    auto output_mem = outputs.at("find").get_memory();
+
+    cldnn::mem_lock<uint8_t> output_ptr(output_mem, network.get_stream());
+
+    std::vector<uint8_t> expected(mask_elements, 0);
+    expected[0] = 1;
+
+    for (size_t i = 0; i < mask_elements; ++i) {
+        ASSERT_EQ(expected[i], output_ptr[i]);
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated xattn_find_block primitive definition and CM implementation that wraps the find_block kernel
- register the CM implementation in the primitive registry and expose the primitive type for graph construction
- add a GPU unit test that exercises the CM kernel on a simple configuration and verifies the resulting block mask

## Testing
- Not run (CI will run)


------
https://chatgpt.com/codex/tasks/task_e_68fb2bcf9844833181d0ad7ffe6d497f