### PR TITLE
Adjust CM paged attention cache layout constants

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/cm/pa_kv_cache_update_ref.cm
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/pa_kv_cache_update_ref.cm
@@ -84,7 +84,7 @@ extern "C" _GENX_MAIN_ void KERNEL_NAME(
     #if KV_CACHE_COMPRESSION_PER_TOKEN
     // Assume: K_HEAD_SIZE == K_HEAD_SIZE
     auto quantize_and_store = [&](vector<half, K_HEAD_SIZE> data, uchar* out, uint out_offset, uint token_pos) {
-            uint scale_offset = out_offset + K_HEAD_SIZE * PAGED_ATTENTION_BLOCK_SIZE + token_pos * sizeof(half);
+            uint scale_offset = out_offset + KEY_SCALE_OFFSET + token_pos * sizeof(half);
             half max_val = cm_reduced_max<half>(data);
             half min_val = cm_reduced_min<half>(data);
             half scale_val = half(0.0);
@@ -106,7 +106,7 @@ extern "C" _GENX_MAIN_ void KERNEL_NAME(
     #endif
 
     {
-        uint block_k_base_offset = (block_indices[block_offset] * KV_HEADS_NUM + head_idx) * ADJUSTED_K_HEAD_SIZE * PAGED_ATTENTION_BLOCK_SIZE;
+        uint block_k_base_offset = (block_indices[block_offset] * KV_HEADS_NUM + head_idx) * KEY_BLOCK_PITCH;
         uint key_out_offset = block_k_base_offset + token_start_pos * K_HEAD_SIZE;
         uint key_in_offset = token_idx * key_pitch + head_idx * K_HEAD_SIZE + key_offset;
 
@@ -120,7 +120,7 @@ extern "C" _GENX_MAIN_ void KERNEL_NAME(
         #endif
     }
     {
-        uint block_v_base_offset = (block_indices[block_offset] * KV_HEADS_NUM + head_idx) * ADJUSTED_V_HEAD_SIZE * PAGED_ATTENTION_BLOCK_SIZE;
+        uint block_v_base_offset = (block_indices[block_offset] * KV_HEADS_NUM + head_idx) * VALUE_BLOCK_PITCH;
         uint value_out_offset = block_v_base_offset + token_start_pos * V_HEAD_SIZE;
         uint value_in_offset = token_idx * value_pitch + head_idx * V_HEAD_SIZE + value_offset;
 

--- a/src/plugins/intel_gpu/src/graph/impls/cm/pa_multi_token.cm
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/pa_multi_token.cm
@@ -136,7 +136,8 @@ extern "C" _GENX_MAIN_ void KERNEL_NAME(
  #endif
 
 #if CMPA_KVCACHE_U8
-    uint kv_offset = hkv*(head_size+4)*pa_block_sz;
+    constexpr uint key_block_pitch = KEY_BLOCK_PITCH;
+    uint kv_offset = hkv*key_block_pitch;
     pa_lsc_u8<is_causal, num_heads, num_kv_heads, head_size, 0>(
                             slm_K,
                             slm_V,

--- a/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention_gen.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention_gen.cpp
@@ -46,12 +46,13 @@ CacheLayoutConstants get_cache_layout_constants(size_t head_size,
     if (!is_compressed)
         return constants;
 
-    const size_t scale_zp_size = data_type_traits::size_of(data_type) * 2;
+    const size_t scale_zp_bytes = sizeof(uint16_t) * 2;
+    const size_t scale_zp_elements = scale_zp_bytes / data_type_traits::size_of(data_type);
     if (is_by_channel) {
-        constants.adjusted_block_size += scale_zp_size;
+        constants.adjusted_block_size += scale_zp_elements;
         constants.scale_offset = block_size;
     } else {
-        constants.adjusted_head_size += scale_zp_size;
+        constants.adjusted_head_size += scale_zp_elements;
         constants.scale_offset = head_size * block_size;
     }
     constants.block_pitch = constants.adjusted_head_size * constants.adjusted_block_size;
@@ -240,8 +241,8 @@ JitConstants PagedAttentionGeneratorKVCacheUpdate::get_jit_constants(const kerne
     const bool is_compressed = get_kv_compressed(params);
     jit.make("KV_CACHE_COMPRESSION_PER_TOKEN", is_compressed ? 1 : 0);
 
-    const auto& key_layout = params.input_layouts[PagedAttentionInputIdx::KEY];
-    const auto& value_layout = params.input_layouts[PagedAttentionInputIdx::VALUE];
+    const auto& key_layout = params.input_layouts[PagedAttentionInputIdx::KEY_CACHE];
+    const auto& value_layout = params.input_layouts[PagedAttentionInputIdx::VALUE_CACHE];
     const auto key_consts = get_cache_layout_constants(desc->k_head_size,
                                                        block_size,
                                                        key_layout.data_type,


### PR DESCRIPTION
## Summary
- compute cache layout helper utilities in the CM paged attention generator so key-by-channel quantization adjusts head and block sizes
- expose key block pitch and scale offset JIT constants while keeping value constants unchanged across single/multi-token and GEMM kernels
- update CM kv-cache update and multi-token kernels to consume the new constants

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6901a2b2102483319b5b78f167f1da01